### PR TITLE
Cambios CSS

### DIFF
--- a/css/loginMaster.css
+++ b/css/loginMaster.css
@@ -47,6 +47,51 @@ body.sidebar-hidden {
     background: var(--header-gradient) !important;
 }
 
+/* === Breadcrumb del topbar (se actualiza al cambiar de pestaña) === */
+.app-breadcrumb {
+    display: flex;
+    align-items: center;
+    margin-left: 0.25rem;
+}
+.app-breadcrumb .breadcrumb {
+    background: transparent !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    font-size: 0.95rem;
+    line-height: 1;
+}
+.app-breadcrumb .breadcrumb-item,
+.app-breadcrumb .breadcrumb-item a {
+    color: rgba(255, 255, 255, 0.75) !important;
+    text-decoration: none;
+    font-weight: 500;
+}
+.app-breadcrumb .breadcrumb-item.active {
+    color: #ffffff !important;
+    font-weight: 600;
+}
+.app-breadcrumb .breadcrumb-item + .breadcrumb-item::before {
+    content: "›";
+    color: rgba(255, 255, 255, 0.55);
+    padding: 0 0.5rem;
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+/* Cuando el sidebar está oculto, dejar transparentes los wrappers
+   para que el gradient azul del body cubra el hueco a la derecha
+   del header (mismo color que el nav y la profile-card).
+   Se incluyen las variantes con .theme-dark para superar la
+   especificidad de body.theme-dark #wrapper... que vive más abajo. */
+body.sidebar-hidden #wrapper,
+body.sidebar-hidden #wrapper #content-wrapper,
+body.sidebar-hidden #wrapper #content-wrapper #content,
+body.theme-dark.sidebar-hidden #wrapper,
+body.theme-dark.sidebar-hidden #wrapper #content-wrapper,
+body.theme-dark.sidebar-hidden #wrapper #content-wrapper #content {
+    background-color: transparent !important;
+}
+
 #wrapper, #content-wrapper, #content, .container-fluid, .row {
     padding: 0 !important;
     margin: 0 !important;
@@ -107,10 +152,14 @@ body.sidebar-hidden {
     flex-direction: column;
 }
 
-.col-xl-9.sidebar-expanded, 
-.col-lg-9.sidebar-expanded, 
+.col-xl-9.sidebar-expanded,
+.col-lg-9.sidebar-expanded,
 .col-md-8.sidebar-expanded,
-.col-md-9.sidebar-expanded {
+.col-md-9.sidebar-expanded,
+body.sidebar-hidden .col-xl-9,
+body.sidebar-hidden .col-lg-9,
+body.sidebar-hidden .col-md-8,
+body.sidebar-hidden .col-md-9 {
     max-width: 100% !important;
     flex: 0 0 100% !important;
     padding-left: 0 !important;
@@ -237,7 +286,7 @@ body.theme-dark .card-header .text-muted {
     background: var(--header-gradient) !important;
     border-radius: 0 !important;
     box-shadow: none !important;
-    padding: 1.25rem 1rem 0 1rem !important;
+    padding: 0 1rem 0 1rem !important;
     margin: 0 !important;
     border: none !important;
     transition: background 0.3s ease;
@@ -1556,12 +1605,6 @@ body:not(.sidebar-hidden) .sticky-footer {
       padding: 2rem 0;
   }
 
-
-
-
-
-
-
   #tabKpis {
       padding: 0 !important;
   }
@@ -1595,10 +1638,6 @@ body:not(.sidebar-hidden) .sticky-footer {
       border: none !important;
       margin: 0 !important;
   }
-
-
-
-
 
   /* Separa del borde superior */
   .profile-avatar {
@@ -1658,7 +1697,7 @@ body:not(.sidebar-hidden) .sticky-footer {
 
   /* Evita que el nombre se pegue */
   .profile-card h4 {
-      margin-top: 50px !important;
+      margin-top: 0px !important;
   }
 body.sidebar-hidden .sticky-footer {
     margin-left: 0 !important;

--- a/encabezado.php
+++ b/encabezado.php
@@ -48,7 +48,15 @@
         <i class="fa fa-bars"></i>
     </button>
 
-   
+    <!-- Breadcrumb dinámico (se actualiza al cambiar de pestaña en #mainTabs) -->
+    <nav id="appBreadcrumb" class="app-breadcrumb" aria-label="breadcrumb">
+        <ol class="breadcrumb mb-0">
+            <li class="breadcrumb-item"><i class="fas fa-home mr-1"></i>Inicio</li>
+            <li class="breadcrumb-item active" id="breadcrumbCurrent" aria-current="page">Sistemas</li>
+        </ol>
+    </nav>
+
+
 
     <!-- Topbar Navbar -->
     <ul class="navbar-nav ml-auto" style="height:60px; align-items:center;">

--- a/inicio.php
+++ b/inicio.php
@@ -1041,6 +1041,22 @@ $esAdmin = isset($_COOKIE['noEmpleadoL']) && in_array($_COOKIE['noEmpleadoL'], $
                 });
             })();
 
+            // Breadcrumb del topbar: refleja la pestaña activa
+            var breadcrumbMap = {
+                'tabSistemas-tab':   'Sistemas',
+                'tabAgenda-tab':     'Sala de Juntas',
+                'tabAvisos-tab':     'Avisos',
+                'tabTickets-tab':    'Tickets',
+                'tabPersonal-tab':   'Personal',
+                'tabVehiculo-tab':   'Vehículo',
+                'tabKpis-tab':       "KPI's",
+                'tabDirectorio-tab': 'Directorio'
+            };
+            $('#mainTabs button[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+                var label = breadcrumbMap[e.target.id];
+                if (label) $('#breadcrumbCurrent').text(label);
+            });
+
             // Calendario de Sala de Juntas: lazy-init al mostrar el tab
             // (FullCalendar mide 0px si se crea con el contenedor en display:none)
             $('#tabAgenda-tab').on('shown.bs.tab', function() {
@@ -2384,7 +2400,11 @@ document.addEventListener('DOMContentLoaded', function() {
         toggleBtn.addEventListener('click', function() {
             sidebarCol.classList.toggle('sidebar-hidden');
             contentCol.classList.toggle('sidebar-expanded');
-            
+            // Sincroniza la clase al <body> para que el fondo cubra el hueco
+            // a la derecha del header (regla body.sidebar-hidden en loginMaster.css).
+            document.body.classList.toggle('sidebar-hidden',
+                sidebarCol.classList.contains('sidebar-hidden'));
+
             // Cambiar icono
             const icon = toggleBtn.querySelector('i');
             if (sidebarCol.classList.contains('sidebar-hidden')) {


### PR DESCRIPTION
- Topbar ahora muestra "Inicio › <Tab activo>" que se actualiza con shown.bs.tab al cambiar de pestaña en #mainTabs.
- Al ocultar el sidebar, el contenido (col-xl-9) se expande al 100% del ancho y los wrappers quedan transparentes para que el gradient azul del body cubra el hueco a la derecha del header.
- Avatar de la profile-card pegado al borde superior del sidebar (padding-top: 0) para eliminar el espacio azul vacío arriba.