### PR TITLE
Actualiza getCookie y manejo de cookies de sesión

### DIFF
--- a/encabezadoGlobal.php
+++ b/encabezadoGlobal.php
@@ -55,10 +55,8 @@
 
     // Función para leer cookies
     function getCookie(name) {
-        let value = "; " + document.cookie;
-        let parts = value.split("; " + name + "=");
-        if (parts.length === 2) return parts.pop().split(";").shift();
-        return null; // Si no encuentra la cookie, retorna null
+        const cookies = new URLSearchParams(document.cookie.replace(/; /g, '&'));
+        return cookies.get(name) || undefined;
     }
 
     // Función para escapar caracteres especiales en HTML

--- a/index.php
+++ b/index.php
@@ -356,7 +356,6 @@ $mail->AltBody = "Hola,\n\nTu contraseña de recuperación es: $passwordRecupera
         });
     }
     // ===== FIN MODAL RECUPERAR CONTRASEÑA =====
-    
     function validaSesion() {
         var usuario = $('#InputEmail').val(); 
         var password = $('#InputPassword').val();
@@ -411,13 +410,14 @@ $mail->AltBody = "Hola,\n\nTu contraseña de recuperación es: $passwordRecupera
                         document.cookie = `fotoL=${encodeURIComponent(data.foto)}; expires=${expires}; SameSite=Lax; path=/;`;
                         document.cookie = `UsrKpis=${encodeURIComponent(data.kpis)}; expires=${expires}; SameSite=Lax; path=/;`;
 
-                        // Cookies para Tickets BI (mismo valor que las *L, sufijo BI)
-                        document.cookie = `id_usuarioBI=${encodeURIComponent(data.id)}; expires=${expires}; SameSite=Lax; path=/;`;
-                        document.cookie = `nombredelusuarioBI=${encodeURIComponent(data.nombre)}; expires=${expires}; SameSite=Lax; path=/;`;
-                        document.cookie = `noEmpleadoBI=${encodeURIComponent(data.noEmpleado)}; expires=${expires}; SameSite=Lax; path=/;`;
-                        document.cookie = `rolBI=${encodeURIComponent(data.rol)}; expires=${expires}; SameSite=Lax; path=/;`;
-                        document.cookie = `correoBI=${encodeURIComponent(data.usuario)}; expires=${expires}; SameSite=Lax; path=/;`;
-                        document.cookie = `fotoBI=${encodeURIComponent(data.foto)}; expires=${expires}; SameSite=Lax; path=/;`;
+                        // Cookies para Tickets BI (mismo valor que las *L, sufijo BI).
+                        // Acotadas a path=/Tickets para que solo existan dentro del sistema de tickets BI.
+                        document.cookie = `id_usuarioBI=${encodeURIComponent(data.id)}; expires=${expires}; SameSite=Lax; path=/Tickets;`;
+                        document.cookie = `nombredelusuarioBI=${encodeURIComponent(data.nombre)}; expires=${expires}; SameSite=Lax; path=/Tickets;`;
+                        document.cookie = `noEmpleadoBI=${encodeURIComponent(data.noEmpleado)}; expires=${expires}; SameSite=Lax; path=/Tickets;`;
+                        document.cookie = `rolBI=${encodeURIComponent(data.rol)}; expires=${expires}; SameSite=Lax; path=/Tickets;`;
+                        document.cookie = `correoBI=${encodeURIComponent(data.usuario)}; expires=${expires}; SameSite=Lax; path=/Tickets;`;
+                        document.cookie = `fotoBI=${encodeURIComponent(data.foto)}; expires=${expires}; SameSite=Lax; path=/Tickets;`;
                     });
 
                     window.location.href = 'inicio';

--- a/inicio.php
+++ b/inicio.php
@@ -2702,10 +2702,8 @@ if (!empty($_COOKIE['noEmpleadoL'])) {
 
         // ===== Cookies =====
         function getCookie(name) {
-            let matches = document.cookie.match(new RegExp(
-                "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
-            ));
-            return matches ? decodeURIComponent(matches[1]) : undefined;
+            const cookies = new URLSearchParams(document.cookie.replace(/; /g, '&'));
+            return cookies.get(name) || undefined;
         }
 
         // ===== Tallas =====

--- a/inicio2.php
+++ b/inicio2.php
@@ -2702,10 +2702,8 @@ if (!empty($_COOKIE['noEmpleadoL'])) {
 
         // ===== Cookies =====
         function getCookie(name) {
-            let matches = document.cookie.match(new RegExp(
-                "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
-            ));
-            return matches ? decodeURIComponent(matches[1]) : undefined;
+            const cookies = new URLSearchParams(document.cookie.replace(/; /g, '&'));
+            return cookies.get(name) || undefined;
         }
 
         // ===== Tallas =====

--- a/inicioOld.php
+++ b/inicioOld.php
@@ -1004,10 +1004,8 @@
 
     //FUNCION PARA OBTENER COOKIES
         function getCookie(name) {
-            let matches = document.cookie.match(new RegExp(
-                "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
-            ));
-            return matches ? decodeURIComponent(matches[1]) : undefined;
+            const cookies = new URLSearchParams(document.cookie.replace(/; /g, '&'));
+            return cookies.get(name) || undefined;
         }
 
     //FUNCION ENVIAR TALLAS

--- a/inicio_res.php
+++ b/inicio_res.php
@@ -1015,10 +1015,8 @@
 
     //FUNCION PARA OBTENER COOKIES
         function getCookie(name) {
-            let matches = document.cookie.match(new RegExp(
-                "(?:^|; )" + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + "=([^;]*)"
-            ));
-            return matches ? decodeURIComponent(matches[1]) : undefined;
+            const cookies = new URLSearchParams(document.cookie.replace(/; /g, '&'));
+            return cookies.get(name) || undefined;
         }
 
     //FUNCION ENVIAR TALLAS

--- a/logout.php
+++ b/logout.php
@@ -18,14 +18,27 @@
 	<script type="text/javascript" class="init">
 	
 $(document).ready(function() {
-    //document.cookie = "antiguedad='.$antiguedad.';expires=" + new Date(Date.now() + 9600000).toUTCString() + ";SameSite=Lax;";
-	document.cookie = "antiguedad=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-	document.cookie = "correo=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-	document.cookie = "diasD=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-	document.cookie = "id_usuario=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-	document.cookie = "noEmpleado=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-	document.cookie = "nombredelusuario=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
-	document.cookie = "rol=00; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+	// Cerrar sesión de loginMaster: borrar TODAS las cookies.
+	var expirada = "Thu, 01 Jan 1970 00:00:00 UTC";
+	var paths = ['/', '/Tickets', '/loginMaster'];
+
+	// Cookies visibles desde esta página (path=/ y /loginMaster).
+	document.cookie.split(';').forEach(function (c) {
+		var eq = c.indexOf('=');
+		var name = (eq > -1 ? c.substr(0, eq) : c).trim();
+		if (!name) return;
+		document.cookie = name + "=; expires=" + expirada + ";";
+		paths.forEach(function (p) {
+			document.cookie = name + "=; expires=" + expirada + "; path=" + p + ";";
+		});
+	});
+
+	// Cookies *BI: viven en path=/Tickets y no son visibles aquí, se borran por nombre.
+	['id_usuarioBI','nombredelusuarioBI','noEmpleadoBI','rolBI','correoBI','fotoBI'].forEach(function (c) {
+		paths.forEach(function (p) {
+			document.cookie = c + "=; expires=" + expirada + "; path=" + p + ";";
+		});
+	});
 
     window.location.assign("index.php")
 } );


### PR DESCRIPTION
- getCookie: nueva implementación con URLSearchParams (reemplaza variantes obsoletas) en encabezadoGlobal, inicio, inicio2, inicio_res e inicioOld
- index.php: cookies *BI acotadas a path=/Tickets (ya no se duplican ni se filtran a otros sistemas)
- logout.php: ahora borra todas las cookies al cerrar sesión (incluidas las *BI en /Tickets)